### PR TITLE
fixed checking whether message is sent

### DIFF
--- a/SmsapiTransport.php
+++ b/SmsapiTransport.php
@@ -65,10 +65,10 @@ final class SmsapiTransport extends AbstractTransport
             ],
         ]);
 
-        if (200 !== $response->getStatusCode()) {
-            $error = $response->toArray(false);
+        $responseContent = $response->toArray(false);
 
-            throw new TransportException(sprintf('Unable to send the SMS: "%s".', $error['message']), $response);
+        if ((isset($responseContent['error']) && null !== $responseContent['error']) || (200 !== $response->getStatusCode()) ) {
+            throw new TransportException(sprintf('Unable to send the SMS: "%s".', $responseContent['message']), $response);
         }
 
         return new SentMessage($message, (string) $this);


### PR DESCRIPTION
SmsAPI always return 200 status code even if we enter incorrect token.
The content is: `{"error":101,"message":"Authorization failed"}`.