### PR TITLE
Make "from" optional

### DIFF
--- a/SmsapiTransport.php
+++ b/SmsapiTransport.php
@@ -30,11 +30,11 @@ final class SmsapiTransport extends AbstractTransport
     protected const HOST = 'api.smsapi.pl';
 
     private string $authToken;
-    private string $from;
+    private ?string $from = null;
     private bool $fast = false;
     private bool $test = false;
 
-    public function __construct(#[\SensitiveParameter] string $authToken, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(#[\SensitiveParameter] string $authToken, string $from = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->authToken = $authToken;
         $this->from = $from;
@@ -64,14 +64,28 @@ final class SmsapiTransport extends AbstractTransport
 
     public function __toString(): string
     {
-        $dsn = sprintf('smsapi://%s?from=%s', $this->getEndpoint(), $this->from);
+        $dsn = sprintf('smsapi://%s', $this->getEndpoint());
+
+        if( null !== $this->from ) {
+            $dsn .= sprintf('?from=%s', (string) $this->from);
+        }
 
         if ($this->fast) {
-            $dsn .= sprintf('&fast=%d', (int) $this->fast);
+            if( strpos($dsn, '?') === false ) 
+                $dsn .= '?';
+            else 
+                $dsn .= '&';
+
+            $dsn .= sprintf('fast=%d', (int) $this->fast);
         }
 
         if ($this->test) {
-            $dsn .= sprintf('&test=%d', (int) $this->test);
+            if( strpos($dsn, '?') === false ) 
+                $dsn .= '?';
+            else 
+                $dsn .= '&';
+
+            $dsn .= sprintf('test=%d', (int) $this->test);
         }
 
         return $dsn;
@@ -88,20 +102,25 @@ final class SmsapiTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
+        $body = [
+            'to' => $message->getPhone(),
+            'message' => $message->getSubject(),
+            'fast' => $this->fast,
+            'format' => 'json',
+            'encoding' => 'utf-8',
+            'test' => $this->test,
+        ];
+
         $from = $message->getFrom() ?: $this->from;
+
+        if( null !== $from ) {
+            $body['from'] = $from;
+        }
 
         $endpoint = sprintf('https://%s/sms.do', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
-            'body' => [
-                'from' => $from,
-                'to' => $message->getPhone(),
-                'message' => $message->getSubject(),
-                'fast' => $this->fast,
-                'format' => 'json',
-                'encoding' => 'utf-8',
-                'test' => $this->test,
-            ],
+            'body' => $body,
         ]);
 
         try {

--- a/SmsapiTransportFactory.php
+++ b/SmsapiTransportFactory.php
@@ -29,7 +29,7 @@ final class SmsapiTransportFactory extends AbstractTransportFactory
         }
 
         $authToken = $this->getUser($dsn);
-        $from = $dsn->getRequiredOption('from');
+        $from = $dsn->getOption('from', null);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $fast = filter_var($dsn->getOption('fast', false), \FILTER_VALIDATE_BOOL);
         $test = filter_var($dsn->getOption('test', false), \FILTER_VALIDATE_BOOL);

--- a/Tests/SmsapiTransportFactoryTest.php
+++ b/Tests/SmsapiTransportFactoryTest.php
@@ -24,6 +24,11 @@ final class SmsapiTransportFactoryTest extends TransportFactoryTestCase
     public function createProvider(): iterable
     {
         yield [
+            'smsapi://host.test',
+            'smsapi://token@host.test',
+        ];
+
+        yield [
             'smsapi://host.test?from=testFrom',
             'smsapi://token@host.test?from=testFrom',
         ];

--- a/Tests/SmsapiTransportTest.php
+++ b/Tests/SmsapiTransportTest.php
@@ -30,6 +30,7 @@ final class SmsapiTransportTest extends TransportTestCase
 
     public function toStringProvider(): iterable
     {
+        yield ['smsapi://test.host', $this->createTransport()];
         yield ['smsapi://test.host?from=testFrom', $this->createTransport()];
         yield ['smsapi://test.host?from=testFrom&fast=1', $this->createTransport(null, true)];
         yield ['smsapi://test.host?from=testFrom&test=1', $this->createTransport(null, false, true)];


### PR DESCRIPTION
Hi,
I make changes in smsapi-notifier consisting of make optional "from" parameter. 

Smsapi.com API have option to display "eco" messages, default with drawn phone number instead of "from" name defined in Smsapi.com user panel.

So, when from is not set in body of request, in default message is send as "eco". My changes make it possible.

